### PR TITLE
Add Ord instance to MD5

### DIFF
--- a/Data/Bson.hs
+++ b/Data/Bson.hs
@@ -123,7 +123,7 @@ merge es doc = foldl f doc es where
 
 infix 0 :=, =:, =?
 
-data Field = (:=) {label :: !Label, value :: Value}  deriving (Typeable, Eq)
+data Field = (:=) {label :: !Label, value :: Value}  deriving (Typeable, Eq, Ord)
 -- ^ A BSON field is a named value, where the name (label) is a string and the value is a BSON 'Value'
 
 (=:) :: (Val v) => Label -> v -> Field
@@ -164,7 +164,7 @@ data Value =
 	Int64 Int64 |
 	Stamp MongoStamp |
 	MinMax MinMaxKey
-	deriving (Typeable, Eq)
+	deriving (Typeable, Eq, Ord)
 
 instance Show Value where
 	showsPrec d v = fval (showsPrec d) v
@@ -378,37 +378,37 @@ fitInt n = if fromIntegral (minBound :: m) <= n && n <= fromIntegral (maxBound :
 
 -- ** Binary types
 
-newtype Binary = Binary S.ByteString  deriving (Typeable, Show, Read, Eq)
+newtype Binary = Binary S.ByteString  deriving (Typeable, Show, Read, Eq, Ord)
 
-newtype Function = Function S.ByteString  deriving (Typeable, Show, Read, Eq)
+newtype Function = Function S.ByteString  deriving (Typeable, Show, Read, Eq, Ord)
 
-newtype UUID = UUID S.ByteString  deriving (Typeable, Show, Read, Eq)
+newtype UUID = UUID S.ByteString  deriving (Typeable, Show, Read, Eq, Ord)
 
 newtype MD5 = MD5 S.ByteString  deriving (Typeable, Show, Read, Eq, Ord)
 
-newtype UserDefined = UserDefined S.ByteString  deriving (Typeable, Show, Read, Eq)
+newtype UserDefined = UserDefined S.ByteString  deriving (Typeable, Show, Read, Eq, Ord)
 
 -- ** Regex
 
-data Regex = Regex Text Text  deriving (Typeable, Show, Read, Eq)
+data Regex = Regex Text Text  deriving (Typeable, Show, Read, Eq, Ord)
 -- ^ The first string is the regex pattern, the second is the regex options string. Options are identified by characters, which must be listed in alphabetical order. Valid options are *i* for case insensitive matching, *m* for multiline matching, *x* for verbose mode, *l* to make \\w, \\W, etc. locale dependent, *s* for dotall mode (\".\" matches everything), and *u* to make \\w, \\W, etc. match unicode.
 
 -- ** Javascript
 
-data Javascript = Javascript Document Text deriving (Typeable, Show, Eq)
+data Javascript = Javascript Document Text deriving (Typeable, Show, Eq, Ord)
 -- ^ Javascript code with possibly empty environment mapping variables to values that the code may reference
 
 -- ** Symbol
 
-newtype Symbol = Symbol Text  deriving (Typeable, Show, Read, Eq)
+newtype Symbol = Symbol Text  deriving (Typeable, Show, Read, Eq, Ord)
 
 -- ** MongoStamp
 
-newtype MongoStamp = MongoStamp Int64  deriving (Typeable, Show, Read, Eq)
+newtype MongoStamp = MongoStamp Int64  deriving (Typeable, Show, Read, Eq, Ord)
 
 -- ** MinMax
 
-data MinMaxKey = MinKey | MaxKey  deriving (Typeable, Show, Read, Eq)
+data MinMaxKey = MinKey | MaxKey  deriving (Typeable, Show, Read, Eq, Ord)
 
 -- ** ObjectId
 

--- a/Data/Bson.hs
+++ b/Data/Bson.hs
@@ -384,7 +384,7 @@ newtype Function = Function S.ByteString  deriving (Typeable, Show, Read, Eq)
 
 newtype UUID = UUID S.ByteString  deriving (Typeable, Show, Read, Eq)
 
-newtype MD5 = MD5 S.ByteString  deriving (Typeable, Show, Read, Eq)
+newtype MD5 = MD5 S.ByteString  deriving (Typeable, Show, Read, Eq, Ord)
 
 newtype UserDefined = UserDefined S.ByteString  deriving (Typeable, Show, Read, Eq)
 


### PR DESCRIPTION
I think most of the Value types should have an Ord instance. This patch just adds it for MD5.
