### PR TITLE
Enhancements in warnings, extensions, and instances

### DIFF
--- a/Data/Bson.hs
+++ b/Data/Bson.hs
@@ -6,10 +6,7 @@
 
 {-# LANGUAGE BangPatterns #-}
 {-# LANGUAGE DeriveDataTypeable #-}
-{-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE ForeignFunctionInterface #-}
-{-# LANGUAGE IncoherentInstances #-}
-{-# LANGUAGE OverlappingInstances #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE TypeSynonymInstances #-}
 

--- a/Data/Bson.hs
+++ b/Data/Bson.hs
@@ -10,7 +10,6 @@
 {-# LANGUAGE ForeignFunctionInterface #-}
 {-# LANGUAGE IncoherentInstances #-}
 {-# LANGUAGE OverlappingInstances #-}
-{-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeSynonymInstances #-}

--- a/Data/Bson.hs
+++ b/Data/Bson.hs
@@ -269,10 +269,13 @@ instance Val Char where
 	cast'List (Sym (Symbol x)) = Just $ T.unpack x
 	cast'List _ = Nothing
 
-instance Val Document where
-	val = Doc
-	cast' (Doc x) = Just x
+instance Val Field where
+	val x = valList [x]
+	valList = Doc
 	cast' _ = Nothing
+	cast'List v = case v of
+		Doc x -> Just x
+		_ -> Nothing
 
 instance Val [Value] where
 	val = Array

--- a/Data/Bson.hs
+++ b/Data/Bson.hs
@@ -257,11 +257,17 @@ instance Val Text where
 	cast' (Sym (Symbol x)) = Just x
 	cast' _ = Nothing
 
-instance Val String where
-	val = String . T.pack
-	cast' (String x) = Just $ T.unpack x
-	cast' (Sym (Symbol x)) = Just $ T.unpack x
-	cast' _ = Nothing
+instance Val Char where
+	val x = valList [x]
+	valList = String . T.pack
+	cast' v = cast'List v >>= safeHead
+		where
+			safeHead list = case list of
+				x : _ -> Just x
+				_ -> Nothing
+	cast'List (String x) = Just $ T.unpack x
+	cast'List (Sym (Symbol x)) = Just $ T.unpack x
+	cast'List _ = Nothing
 
 instance Val Document where
 	val = Doc

--- a/Data/Bson.hs
+++ b/Data/Bson.hs
@@ -277,10 +277,9 @@ instance Val Field where
 		Doc x -> Just x
 		_ -> Nothing
 
-instance Val [Value] where
-	val = Array
-	cast' (Array x) = Just x
-	cast' _ = Nothing
+instance Val Value where
+	val = id
+	cast' = Just
 
 instance (Val a) => Val [a] where
 	val = valList
@@ -330,12 +329,6 @@ instance Val POSIXTime where
 	val = UTC . posixSecondsToUTCTime . roundTo (1/1000)
 	cast' (UTC x) = Just (utcTimeToPOSIXSeconds x)
 	cast' _ = Nothing
-
-instance Val (Maybe Value) where
-	val Nothing = Null
-	val (Just v) = v
-	cast' Null = Just Nothing
-	cast' v = Just (Just v)
 
 instance (Val a) => Val (Maybe a) where
 	val = valMaybe

--- a/Data/Bson.hs
+++ b/Data/Bson.hs
@@ -4,10 +4,16 @@
 -- Use the GHC language extension /OverloadedStrings/ to automatically convert
 -- String literals to Text
 
-{-# LANGUAGE OverloadedStrings, TypeSynonymInstances, FlexibleInstances #-}
-{-# LANGUAGE DeriveDataTypeable, RankNTypes, OverlappingInstances #-}
-{-# LANGUAGE IncoherentInstances, ScopedTypeVariables #-}
-{-# LANGUAGE ForeignFunctionInterface, BangPatterns #-}
+{-# LANGUAGE BangPatterns #-}
+{-# LANGUAGE DeriveDataTypeable #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE ForeignFunctionInterface #-}
+{-# LANGUAGE IncoherentInstances #-}
+{-# LANGUAGE OverlappingInstances #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeSynonymInstances #-}
 
 module Data.Bson (
 	-- * Document


### PR DESCRIPTION
This patch series consists of three enhancements:
1. Make instances coherent and non-overlapping.
2. Disuse some language extensions.
3. Make the code compile without warning.
